### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/makey.el
+++ b/makey.el
@@ -5,6 +5,7 @@
 
 ;; Author: Mickey Petersen <mickey@masteringemacs.org>
 ;; Keywords:
+;; Package-Requires: ((cl-lib "0.2"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
cl-lib is not standard in all Emacsen which support package.el.

(Background: I am adding this to MELPA, along with discover.el)
